### PR TITLE
[FIX] Add Condition for removing release type tags in release workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,7 @@ jobs:
     steps: 
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Process Pull Request
         id: process-pr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository 
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Use Node.js "18.x"
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ on:
 
   schedule:
     # Schedule automatic release every Wednesday
-    # - cron: "0 0 * * 3"
+    - cron: "0 0 * * 3"
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        # TODO: Have to use this commit because fetch-tags is not working in main till this is merged to main
-        uses: actions/checkout@0548471950d86b19eae6c063105707c831fb5c03
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.ref }}
           fetch-tags: true


### PR DESCRIPTION
## Describe your changes
- Fix condition for removing release type tags in release workflow
- Fix checkout action to use stable version instead of specific commit
- Upgrade actions/checkout to v6 in workflows